### PR TITLE
Add api methods to fix patient data owner corruption in medtech

### DIFF
--- a/lib/api_helper.dart
+++ b/lib/api_helper.dart
@@ -85,7 +85,7 @@ Map<String, V> mapOf<V>(dynamic json, V Function(dynamic json) valueMappingOp) {
   if (json is Map && json.isNotEmpty) {
     json = json.cast<String, dynamic>(); // ignore: parameter_assignments
     for (final entry in json.entries) {
-      final value = valueMappingOp(json);
+      final value = valueMappingOp(entry.value);
       if (value != null) {
         map[entry.key] = value;
       }

--- a/lib/extended_api/data_owner_resolver.dart
+++ b/lib/extended_api/data_owner_resolver.dart
@@ -65,6 +65,17 @@ class DataOwnerResolver {
   }
 
   Future<DataOwnerDto?> updateDataOwnerWithNewDelegateKeyPair(String dataOwnerId, Map<String, List<String>> newKeyPair) async {
+    try {
+      return await _doUpdateDataOwnerWithNewDelegateKeyPair(dataOwnerId, newKeyPair);
+    } on ApiException {
+      hcParties.remove(dataOwnerId);
+      patients.remove(dataOwnerId);
+      devices.remove(dataOwnerId);
+      return _doUpdateDataOwnerWithNewDelegateKeyPair(dataOwnerId, newKeyPair);
+    }
+  }
+
+  Future<DataOwnerDto?> _doUpdateDataOwnerWithNewDelegateKeyPair(String dataOwnerId, Map<String, List<String>> newKeyPair) async {
     return Future.wait([
       _updateHcpWithNewDelegateKeyPair(dataOwnerId, newKeyPair),
       _updatePatientWithNewDelegateKeyPair(dataOwnerId, newKeyPair),
@@ -196,11 +207,12 @@ class DataOwnerResolver {
 }
 
 class DataOwnerDto {
-  DataOwnerDto(this.type, this.dataOwnerId, this.hcPartyKeys, {this.publicKey = null, this.parentId = null, this.rev = null});
+  DataOwnerDto(this.type, this.dataOwnerId, this.hcPartyKeys, {this.publicKey = null, this.parentId = null, this.rev = null, this.aesExchangeKeys = const {} });
 
   final DataOwnerType type;
   final String dataOwnerId;
   final Map<String, List<String>> hcPartyKeys;
+  final Map<String, Map<String, Map<String, String>>> aesExchangeKeys;
   final String? publicKey;
   final String? parentId;
   final String? rev;

--- a/lib/model/decrypted/patient_dto.dart
+++ b/lib/model/decrypted/patient_dto.dart
@@ -455,7 +455,7 @@ class DecryptedPatientDto {
 
   /// Extra AES exchange keys, usually the ones we lost access to at some point
   /// The structure is { publicKey: { delegateId: [aesExKey_for_this, aesExKey_for_delegate] } }
-  Map<String, Map<String, List<String>>> aesExchangeKeys;
+  Map<String, Map<String, Map<String, String>>> aesExchangeKeys;
 
   /// Data owner private keys encrypted with its other public keys.
   /// This mechanism will help the data owner to re-encrypt all information with its new key, if he found back the lost one.
@@ -1020,7 +1020,7 @@ class DecryptedPatientDto {
         parameters: json[r'parameters'] == null ? const {} : mapWithListOfStringsFromJson(json[r'parameters']),
         properties: PropertyStubDto.listFromJson(json[r'properties'])!.toSet(),
         hcPartyKeys: json[r'hcPartyKeys'] == null ? const {} : mapWithListOfStringsFromJson(json[r'hcPartyKeys']),
-        aesExchangeKeys: json[r'aesExchangeKeys'] == null ? const {} : mapOf(json[r'aesExchangeKeys'], (el) => mapWithListOfStringsFromJson(el)),
+        aesExchangeKeys: json[r'aesExchangeKeys'] == null ? const {} : mapOf(json[r'aesExchangeKeys'], (el) => mapWithMapOfStringsFromJson(el)),
         transferKeys: json[r'transferKeys'] == null ? const {} : mapWithMapOfStringsFromJson(json[r'transferKeys']),
         privateKeyShamirPartitions: mapCastOfType<String, String>(json, r'privateKeyShamirPartitions')!,
         publicKey: mapValueOfType<String>(json, r'publicKey'),

--- a/lib/model/device_dto.dart
+++ b/lib/model/device_dto.dart
@@ -187,7 +187,7 @@ class DeviceDto {
 
   /// Extra AES exchange keys, usually the ones we lost access to at some point
   /// The structure is { publicKey: { delegateId: [aesExKey_for_this, aesExKey_for_delegate] } }
-  Map<String, Map<String, List<String>>> aesExchangeKeys;
+  Map<String, Map<String, Map<String, String>>> aesExchangeKeys;
 
   /// Data owner private keys encrypted with its other public keys.
   /// This mechanism will help the data owner to re-encrypt all information with its new key, if he found back the lost one.
@@ -378,7 +378,7 @@ class DeviceDto {
         picture: json[r'picture'] is List ? (json[r'picture'] as List).cast<String>() : const [],
         properties: PropertyStubDto.listFromJson(json[r'properties'])!.toSet(),
         hcPartyKeys: json[r'hcPartyKeys'] == null ? const {} : mapWithListOfStringsFromJson(json[r'hcPartyKeys']),
-        aesExchangeKeys: json[r'aesExchangeKeys'] == null ? const {} : mapOf(json[r'aesExchangeKeys'], (el) => mapWithListOfStringsFromJson(el)),
+        aesExchangeKeys: json[r'aesExchangeKeys'] == null ? const {} : mapOf(json[r'aesExchangeKeys'], (el) => mapWithMapOfStringsFromJson(el)),
         transferKeys: json[r'transferKeys'] == null ? const {} : mapWithMapOfStringsFromJson(json[r'transferKeys']),
         privateKeyShamirPartitions: mapCastOfType<String, String>(json, r'privateKeyShamirPartitions')!,
         publicKey: mapValueOfType<String>(json, r'publicKey'),

--- a/lib/model/healthcare_party_dto.dart
+++ b/lib/model/healthcare_party_dto.dart
@@ -369,7 +369,7 @@ class HealthcarePartyDto {
 
   /// Extra AES exchange keys, usually the ones we lost access to at some point
   /// The structure is { publicKey: { delegateId: [aesExKey_for_this, aesExKey_for_delegate] } }
-  Map<String, Map<String, List<String>>> aesExchangeKeys;
+  Map<String, Map<String, Map<String, String>>> aesExchangeKeys;
 
   /// Data owner private keys encrypted with its other public keys.
   /// This mechanism will help the data owner to re-encrypt all information with its new key, if he found back the lost one.
@@ -684,7 +684,7 @@ class HealthcarePartyDto {
         options: mapCastOfType<String, String>(json, r'options')!,
         properties: PropertyStubDto.listFromJson(json[r'properties'])!.toSet(),
         hcPartyKeys: json[r'hcPartyKeys'] == null ? const {} : mapWithListOfStringsFromJson(json[r'hcPartyKeys']),
-        aesExchangeKeys: json[r'aesExchangeKeys'] == null ? const {} : mapOf(json[r'aesExchangeKeys'], (el) => mapWithListOfStringsFromJson(el)),
+        aesExchangeKeys: json[r'aesExchangeKeys'] == null ? const {} : mapOf(json[r'aesExchangeKeys'], (el) => mapWithMapOfStringsFromJson(el)),
         transferKeys: json[r'transferKeys'] == null ? const {} : mapWithMapOfStringsFromJson(json[r'transferKeys']),
         privateKeyShamirPartitions: mapCastOfType<String, String>(json, r'privateKeyShamirPartitions')!,
         publicKey: mapValueOfType<String>(json, r'publicKey'),

--- a/lib/model/patient_dto.dart
+++ b/lib/model/patient_dto.dart
@@ -455,7 +455,7 @@ class PatientDto {
 
   /// Extra AES exchange keys, usually the ones we lost access to at some point
   /// The structure is { publicKey: { delegateId: [aesExKey_for_this, aesExKey_for_delegate] } }
-  Map<String, Map<String, List<String>>> aesExchangeKeys;
+  Map<String, Map<String, Map<String, String>>> aesExchangeKeys;
 
   /// Data owner private keys encrypted with its other public keys.
   /// This mechanism will help the data owner to re-encrypt all information with its new key, if he found back the lost one.
@@ -991,7 +991,7 @@ class PatientDto {
         parameters: json[r'parameters'] == null ? const {} : mapWithListOfStringsFromJson(json[r'parameters']),
         properties: PropertyStubDto.listFromJson(json[r'properties'])!.toSet(),
         hcPartyKeys: json[r'hcPartyKeys'] == null ? const {} : mapWithListOfStringsFromJson(json[r'hcPartyKeys']),
-        aesExchangeKeys: json[r'aesExchangeKeys'] == null ? const {} : mapOf(json[r'aesExchangeKeys'], (el) => mapWithListOfStringsFromJson(el)),
+        aesExchangeKeys: json[r'aesExchangeKeys'] == null ? const {} : mapOf(json[r'aesExchangeKeys'], (el) => mapWithMapOfStringsFromJson(el)),
         transferKeys: json[r'transferKeys'] == null ? const {} : mapWithMapOfStringsFromJson(json[r'transferKeys']),
         privateKeyShamirPartitions: mapCastOfType<String, String>(json, r'privateKeyShamirPartitions')!,
         publicKey: mapValueOfType<String>(json, r'publicKey'),


### PR DESCRIPTION
- Add method to crypto api to find delegation keys which are not already shared between delegator and delegate
- Fix aes exchange keys types
- Add methods to health element and contact api which require only the necessary fields of the DecryptedPatientDto